### PR TITLE
Removed "Sendping" from navbar.

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -52,9 +52,9 @@
         <?php if ($charInfo->director): ?>
           <li><a href="/admin/users">Users</a></li>
         <?php endif; ?>
-        <?php if ($charInfo->officer): ?>
+        <!--<?php if ($charInfo->officer): ?>
           <li><a href="/admin/sendping">Send Ping</a></li>
-        <?php endif; ?>
+        <?php endif; ?> -->
         <li class="dropdown">
           <a href="/top">Rankings</a>
         </li>


### PR DESCRIPTION
Ping server has been taken down, as stahp is not used anymore and VPS running Ping-Server have been re-purposed. Removed the link to the page for sending pings. In future it could be restored if necessary.